### PR TITLE
Chat Dotnet - replaced hardcoded DIDs with command line arguments

### DIFF
--- a/chat/dotnet/Program.cs
+++ b/chat/dotnet/Program.cs
@@ -87,7 +87,7 @@ namespace Layr8Chat
                 {
                     try
                     {
-                        channel = socket.Channel("plugins:did:web:earth.node.layr8.org:truckit-airticket-1", new Dictionary<string, object>
+                        channel = socket.Channel($"plugins:{did}", new Dictionary<string, object>
                         {
                             { "payload_types", new[]
                                 {
@@ -148,7 +148,7 @@ namespace Layr8Chat
                                         {
                                             ["id"]= Guid.NewGuid().ToString(),
                                             ["from"]= did,
-                                            ["to"] = new[] { "did:web:venus.node.layr8.org:demo-contractor-1" },
+                                            ["to"] = new[] { recipient_did },
                                             ["type"] = "https://didcomm.org/basicmessage/2.0/message",
                                             ["body"] = new Dictionary<string, object>
                                             {
@@ -159,8 +159,6 @@ namespace Layr8Chat
 
                                         var push = new Push(channel, "message", messagePayload, 10000);
                                         push.Send().Wait();
-                                        //Console.WriteLine("Message sent!");
-                                        Console.Write("\nEnter message > ");
                                     }
                                 }
                             }


### PR DESCRIPTION
Also removed the 
> Console.Write("\nEnter message > ");

It was being written twice due to the response code on line 122.